### PR TITLE
fixes React site build failure

### DIFF
--- a/lab2/client/package.json
+++ b/lab2/client/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts --openssl-legacy-provider build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Build was failing with error `error:0308010C:digital envelope routines::unsupported`. Adding a `--openssl-legacy-provider` with build command fixes it. Tested in Cloud9 environment, that is created for the labs.

*Issue #, if available: #31

*Description of changes: added a `--openssl-legacy-provider` flag with npm build command in `package.json`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
