### PR TITLE
updated references from master branch to main

### DIFF
--- a/resources/lab1.template
+++ b/resources/lab1.template
@@ -709,7 +709,7 @@ Resources:
                 Provider: CodeCommit
                 Version: 1
               Configuration:
-                BranchName: master
+                BranchName: main
                 RepositoryName: !GetAtt CodeCommitRepo.Name
                 PollForSourceChanges: false
               RunOrder: 1
@@ -781,7 +781,7 @@ Resources:
           referenceType:
             - branch
           referenceName:
-            - master
+            - main
       Targets:
         - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${CodePipeline}
           RoleArn: !GetAtt CloudWatchEventRoleForCloudTrail.Arn

--- a/resources/lab2.template
+++ b/resources/lab2.template
@@ -348,7 +348,7 @@ Resources:
                 Provider: CodeCommit
                 Version: 1
               Configuration:
-                BranchName: master
+                BranchName: main
                 RepositoryName: !Ref CodeCommitRepoName
                 PollForSourceChanges: false
               RunOrder: 1
@@ -420,7 +420,7 @@ Resources:
           referenceType:
             - branch
           referenceName:
-            - master
+            - main
       Targets:
         - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${CodePipelineLab2}
           RoleArn: !GetAtt CloudWatchEventRoleForCloudTrailLab2.Arn


### PR DESCRIPTION
*Issue #33*

*Description of changes:*
Updated Lab1.template to change the CodePipeline Source stage to pull from the `main` branch rather than `master` to match the changes made in the primary workshop template with code commit repo having `main` as the default branch.

Also updated the associated CloudWatch Event to also target `main`

Have tested Pipeline in Lab1, but not beyond. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
